### PR TITLE
Lower pandas version requirement in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ dev_requirements = [
 
 requirements = [
     "cdp-backend>=3.0.3",
-    "pandas>=1.4.0",
+    "pandas>=1.3.5",
 ]
 
 extra_requirements = {


### PR DESCRIPTION
Change requirements for pandas: "pandas>=1.4.0"  =====> "pandas>=1.3.5"

<!--
  Thank you for submitting a pull request!

  ⚠️⚠️ Please do the following before submitting: ⚠️⚠️

  - Read the CONTRIBUTING.md guide and make sure you've followed all the steps given.
  - Ensure that the code is up-to-date with the `main` branch.
  - Provide or update documentation for any feature added by your pull request.
  - Provide relevant tests for your feature or bug fix.

  ❗️ Also: ❗️

  Please name your pull request {development-type}/{short-description}.
  For example: feature/read-tiff-files
-->

### Link to Relevant Issue

This pull request resolves # Tried using Colab and Kaggle for their free GPU and threw errors as they both run on pandas 1.3.5 still. 

### Description of Changes

<!-- Include a description of the proposed changes. -->
